### PR TITLE
Improve Windows support and add Visual Studio NMake Makefiles

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -319,6 +319,18 @@
 	    is built as a DLL, on DLL_PROCESS_DETACH.  Ensure that tests
 	    builds as well since src/thbrk/brk-common.c is also used.
 
+2020-03-23  Ross Burton <ross.burton@intel.com>
+
+	configure.ac: remove duplicate AC_CONFIG_MACRO_DIR
+
+	Autoconf 2.70 will fatally error out if AC_CONFIG_MACRO_DIR is called
+	more than once:
+
+	| configure.ac:25: error: AC_CONFIG_MACRO_DIR can only be used once
+
+	* configure.ac:
+	  - Remove duplicate AC_CONFIG_MACRO_DIR
+
 2020-01-14  Theppitak Karoonboonyanan  <theppitak@gmail.com>
 
 	Update word break dictionary.

--- a/ChangeLog
+++ b/ChangeLog
@@ -293,6 +293,16 @@
 	* configure.ac:
 	  - Remove duplicate AC_CONFIG_MACRO_DIR
 2020-02-14  Chun-wei Fan  <fanc999@yahoo.com.tw>
+
+	Add a set of NMake Makefiles
+	* configure.ac:
+	* Makefile.am:
+	* win32/*:
+	  - Add a set of NMake Makefiles for Visual Studio 2008 and later,
+	    for building libthai as a DLL as well as the pkg-config file.
+	    Buliding the dictionary file and tests are also supported.
+
+2020-02-14  Chun-wei Fan  <fanc999@yahoo.com.tw>
 	Make libthai relocatable on native Windows
 
 	* src/thbrk/brk-common.c:

--- a/ChangeLog
+++ b/ChangeLog
@@ -293,6 +293,13 @@
 	* configure.ac:
 	  - Remove duplicate AC_CONFIG_MACRO_DIR
 2020-02-14  Chun-wei Fan  <fanc999@yahoo.com.tw>
+	Make libthai relocatable on native Windows
+
+	* src/thbrk/brk-common.c:
+	  - Deduce location of DLL or statically-linked EXE and construct
+	    path dynamically where thbrk.tri can be loaded.
+
+2020-02-14  Chun-wei Fan  <fanc999@yahoo.com.tw>
 
 	Don't use __attribute__((destructor)) on MSVC builds
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -292,6 +292,15 @@
 
 	* configure.ac:
 	  - Remove duplicate AC_CONFIG_MACRO_DIR
+2020-02-14  Chun-wei Fan  <fanc999@yahoo.com.tw>
+
+	Don't use __attribute__((destructor)) on MSVC builds
+
+	* src/libthai.c:
+	* src/thbrk/brk-common.c:
+	  - Instead define a DLLMain that does the same thing when libthai
+	    is built as a DLL, on DLL_PROCESS_DETACH.  Ensure that tests
+	    builds as well since src/thbrk/brk-common.c is also used.
 
 2020-01-14  Theppitak Karoonboonyanan  <theppitak@gmail.com>
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = include src data tests doc
+SUBDIRS = include src data tests doc win32
 
 EXTRA_DIST = \
 	build-aux/git-version-gen	\

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,8 @@ AC_CONFIG_FILES([libthai.pc
   tests/Makefile
   doc/Makefile
   doc/Doxyfile
+  win32/Makefile
+  win32/config-msvc.mak
 ])
 AC_OUTPUT
 

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -90,7 +90,11 @@
 
 #include "thbrk/thbrk-priv.h"
 
-__attribute__ ((destructor)) void
+
+#if defined (__GNUC__) || defined (__clang__)
+__attribute__((destructor))
+#endif
+void
 _libthai_on_unload ()
 {
     brk_free_shared_brk ();

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -51,6 +51,9 @@ extern void _libthai_on_unload ();
 #endif /* MSVC_BUILD_LIBTHAI_TESTS */
 #endif /* !__GNUC__ && !__clang__ */
 
+/* This way, we can use the current directory where the .exe is if no DLL is built, such as in tests */
+static HMODULE libthai_dll = NULL;
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL,
                     DWORD     fdwReason,
                     LPVOID    lpvReserved);
@@ -59,19 +62,77 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL,
                     DWORD     fdwReason,
                     LPVOID    lpvReserved)
 {
-
-#if !defined (__GNUC__) && !defined (__clang__)
-    /* fallback for lack of GCC's __attribute__((destructor)) */
     switch (fdwReason)
         {
+            case DLL_PROCESS_ATTACH:
+                libthai_dll = hinstDLL;
+                break;
+
+#if !defined (__GNUC__) && !defined (__clang__)
+            /* fallback for lack of GCC's __attribute__((destructor)) */
             case DLL_PROCESS_DETACH:
                 _libthai_on_unload ();
                 break;
-        }
 #endif
+        }
 
     return TRUE;
 }
+
+/*
+ * modelled around GLib's g_win32_get_package_installation_directory_of_module()
+ * without Cygwin support
+ */
+#ifndef __CYGWIN__
+char *
+libthai_get_installdir (HMODULE hmodule)
+{
+    char *retval;
+	char *filename;
+    char *p;
+    wchar_t wc_fn[MAX_PATH];
+    size_t length;
+    size_t converted = 0;
+
+    /* NOTE: it relies that GetModuleFileNameW returns only canonical paths */
+    if (!GetModuleFileNameW (hmodule, wc_fn, MAX_PATH))
+      return NULL;
+
+    length = wcslen(wc_fn);
+    filename = (char *)malloc (sizeof(char) * (length * 2 + 1));
+    wcstombs_s(&converted, filename, length * 2, wc_fn, _TRUNCATE);
+
+    if ((p = strrchr (filename, '\\')) != NULL)
+        *p = '\0';
+
+    retval = (char *)malloc (sizeof(char) * (length * 2 + 1));
+	memcpy (retval, filename, strlen(filename));
+
+    do
+        {
+            p = strrchr (retval, '\\');
+            if (p == NULL)
+                break;
+
+            *p = '\0';
+
+            if (_stricmp (p + 1, "bin") == 0 ||
+                _stricmp (p + 1, "lib") == 0)
+                break;
+        }
+    while (p != NULL);
+
+    if (p == NULL)
+        {
+          free (retval);
+          retval = filename;
+        }
+    else
+        free (filename);
+
+    return retval;
+}
+#endif /* !__CYGWIN__ */
 #endif /* _WIN32 */
 
 #define DICT_NAME   "thbrk"
@@ -99,9 +160,20 @@ brk_load_default_dict ()
         free (path);
     }
 
-    /* Then, fall back to default DICT_DIR macro */
+    /* Then, fall back to default DICT_DIR macro or relative $(datadir)\share\libthai for native Windows DLL */
     if (!dict_trie) {
+#if defined (_WIN32) && !defined (__CYGWIN__)
+        char *basedir = libthai_get_installdir (libthai_dll);
+        const char *sharedir = "share\\libthai\\" DICT_NAME ".tri";
+        size_t total_len = strlen (basedir) + strlen (sharedir) + 1; /* '+ 1' for the '\\' that we are using below */
+        char *filepath = (char *) malloc (sizeof (char) * (total_len + 1));
+        sprintf (filepath, "%s\\%s", basedir, sharedir);
+        dict_trie = trie_new_from_file (filepath);
+        free (filepath);
+        free (basedir);
+#else
         dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
+#endif
     }
 
     return dict_trie;

--- a/win32/Makefile.am
+++ b/win32/Makefile.am
@@ -1,0 +1,13 @@
+EXTRA_DIST =	\
+	build-rules-msvc.mak	\
+	config-msvc.mak		\
+	create-lists-msvc.mak	\
+	create-lists.bat	\
+	create-pc.bat	\
+	detectenv-msvc.mak	\
+	generate-msvc.mak	\
+	info-msvc.mak	\
+	install.mak	\
+	Makefile.vc	\
+	README.txt	\
+	$(NULL)

--- a/win32/Makefile.vc
+++ b/win32/Makefile.vc
@@ -1,0 +1,45 @@
+# NMake Makefile for building libthai on Windows
+
+# The items below this line should not be changed, unless one is maintaining
+# the NMake Makefiles.  Customizations can be done in the following NMake Makefile
+# portions (please see comments in the these files to see what can be customized):
+#
+# detectenv-msvc.mak
+# config-msvc.mak
+
+!include detectenv-msvc.mak
+
+# Include the Makefile portion that enables features based on user input
+!include config-msvc.mak
+
+!if "$(VALID_CFGSET)" == "TRUE"
+
+
+all: $(LIBTHAI_LIBS) $(LIBTHAI_DATA) all-build-info
+
+# Include the Makefile portion to convert the source and header lists
+# into the lists we need for compilation and introspection
+!include create-lists-msvc.mak
+
+tests: all $(libthai_tests_EXES)
+	@for %x in (ctype cell inp rend str wchar) do vs$(PDBVER)\$(CFG)\$(PLAT)\test_th%x.exe
+	vs$(PDBVER)\$(CFG)\$(PLAT)\thsort.exe ..\tests\sorttest.txt vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\out.txt
+	@fc ..\tests\sorted.txt vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\out.txt
+	@del vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\out.txt
+	@if "$(LIB_ONLY)" == "" @(for %x in (brk wbrk) do (set LIBTHAI_DICTDIR=$(MAKEDIR)\vs$(PDBVER)\$(CFG)\$(PLAT)\) & (vs$(PDBVER)\$(CFG)\$(PLAT)\test_th%x.exe))
+
+# Include the build rules for sources, DLLs and executables
+!include build-rules-msvc.mak
+
+# Include the rules for build directory creation and code generation
+!include generate-msvc.mak
+
+!include install.mak
+
+!else # "$(VALID_CFGSET)" == "TRUE"
+all: help
+	@echo You need to specify a valid configuration, via
+	@echo CFG=release or CFG=debug
+!endif # "$(VALID_CFGSET)" == "TRUE"
+
+!include info-msvc.mak

--- a/win32/README.txt
+++ b/win32/README.txt
@@ -1,0 +1,54 @@
+Instructions for building libthai on Visual Studio
+==================================================
+Building the libthai on Windows is now supported using Visual Studio.
+
+You will need the following items to build libthai using Visual Studio:
+-libiconv (including the libcharset headers and libraries) if building trietool.exe
+
+Invoke the build by issuing the command:
+nmake /f Makefile.vc CFG=[release|debug] [PREFIX=...] <option1=1 option2=1 ...>
+where:
+
+CFG: Required.  Choose from a release or debug build.  Note that
+     all builds generate a .pdb file for each .dll and .exe built--this refers
+     to the C/C++ runtime that the build uses.
+
+PREFIX: Optional.  Base directory of where the third-party headers, libraries
+        and needed tools can be found, i.e. headers in $(PREFIX)\include,
+        libraries in $(PREFIX)\lib and tools in $(PREFIX)\bin.  If not
+        specified, $(PREFIX) is set as $(srcroot)\..\vs$(X)\$(platform), where
+        $(platform) is win32 for 32-bit builds or x64 for 64-bit builds, and
+        $(X) is the short version of the Visual Studio used, as follows:
+        2008: 9
+        2010: 10
+        2012: 11
+        2013: 12
+        2015, 2017, 2019: 14
+
+Explanation of options, set by <option>=1 unless otherwise noted:
+-----------------------------------------------------------------
+LIB_ONLY: Disables building the Thai dictionary data file, which eliminates the need for
+          trietool.exe, which requires libiconv with libcharset to run.
+
+LIBDATRIE_INCLUDE_BASE: Base directory where the headers of libdatrie can be found, which
+                        is $(LIBDATRIE_INCLUDE_BASE)\datrie.  If not specified, 
+                        $(PREFIX)\include is used for this value.
+
+LIBDATRIE_LIB: Full path or name of .lib of libdatrie, if datrie.lib cannot be found in
+               in the paths indicated by %LIB% or $(PREFIX)\lib.
+TRIETOOL: Location of the trietool.exe program from libdatrie, if LIB_ONLY is not specified.
+          If not specified, $(PREFIX)\bin\trietool.exe will be used for this value.
+
+If you encounter C4819 warnings and/or C2001 errors (newline in constant), you will need to
+set your system locale to English (United States) using Control Panel->Time and Region Settings->
+Region->System Management->Encoding for non-Unicode programs, reboot, and clean up and retry
+the build.  Note that the /utf-8 compiler flag in Visual Studio 2015 or later is not sufficient.
+Please note that warning C4819 should not be ignored, as it is an indication that the build
+might have been done incorrectly.
+
+An 'install' target is provided to copy the built items and public headers to appropriate
+locations under $(PREFIX), a 'clean' target is provided to remove all the items that are
+created during the build, and a 'tests' target is provided to build and run the test programs.
+Note that it is necessary that the libdatrie DLL is found in %PATH% or is copied to $(outdir)
+to run the test_thbrk and test_thwbrk test programs, if building against a DLL build of
+libdatrie.

--- a/win32/build-rules-msvc.mak
+++ b/win32/build-rules-msvc.mak
@@ -1,0 +1,145 @@
+# NMake Makefile portion for compilation rules
+# Items in here should not need to be edited unless
+# one is maintaining the NMake build files.  The format
+# of NMake Makefiles here are different from the GNU
+# Makefiles.  Please see the comments about these formats.
+
+# Inference rules for compiling the .obj files.
+# Used for libs and programs with more than a single source file.
+# Format is as follows
+# (all dirs must have a trailing '\'):
+#
+# {$(srcdir)}.$(srcext){$(destdir)}.obj::
+# 	$(CC)|$(CXX) $(cflags) /Fo$(destdir) /c @<<
+# $<
+# <<
+{..\src\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thbrk\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thcell\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thcoll\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thctype\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thinp\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thrend\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thstr\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thwbrk\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thwchar\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thwctype\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\src\thwstr\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\}.obj::
+	$(CC) $(CFLAGS) $(LIBTHAI_BASE_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ /c @<<
+$<
+<<
+
+{..\tests\}.c{vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\}.obj::
+	@if not exist vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\ $(MAKE) /f Makefile.vc CFG=$(CFG) vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests
+	$(CC) $(CFLAGS) $(LIBTHAI_TEST_CFLAGS) /Fovs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\ /Fdvs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\ /c @<<
+$<
+<<
+
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\brk-common-test.obj: ..\src\thbrk\brk-common.c
+	@if not exist vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\ $(MAKE) /f Makefile.vc CFG=$(CFG) vs$(PDBVER)\$(CFG)\$(PLAT)\libthai
+	$(CC) $(CFLAGS) $(LIBTHAI_TEST_CFLAGS) /Fo$@ /Fd$(@D)\ $** /c
+
+# Rules for building .lib files
+vs$(PDBVER)\$(CFG)\$(PLAT)\thai.lib: vs$(PDBVER)\$(CFG)\$(PLAT)\thai.dll
+
+# Rules for linking DLLs
+# Format is as follows (the mt command is needed for MSVC 2005/2008 builds):
+# $(dll_name_with_path): $(dependent_libs_files_objects_and_items)
+#	link /DLL [$(linker_flags)] [$(dependent_libs)] [/def:$(def_file_if_used)] [/implib:$(lib_name_if_needed)] -out:$@ @<<
+# $(dependent_objects)
+# <<
+# 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
+vs$(PDBVER)\$(CFG)\$(PLAT)\thai.dll:		\
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\thai.def	\
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai.pc	\
+$(libthai_dll_OBJS)
+	link /DLL $(LDFLAGS) /implib:$(@R).lib /def:vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\thai.def	\
+	$(LIBTHAI_DEP_LIBS) -out:$@ @<<
+$(libthai_dll_OBJS)
+<<
+	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;2
+
+# Rules for linking Executables
+# Format is as follows (the mt command is needed for MSVC 2005/2008 builds):
+# $(dll_name_with_path): $(dependent_libs_files_objects_and_items)
+#	link [$(linker_flags)] [$(dependent_libs)] -out:$@ @<<
+# $(dependent_objects)
+# <<
+# 	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thctype.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thctype.obj $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thcell.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thcell.obj $(libthai_thcell_OBJS) $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thinp.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thinp.obj $(libthai_thinp_OBJS) $(libthai_thcell_OBJS) $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thrend.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thrend.obj $(libthai_thrend_OBJS) $(libthai_thcell_OBJS) $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thstr.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thstr.obj $(libthai_thstr_OBJS) $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\thsort.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\thsort.obj $(libthai_thcoll_OBJS) $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thbrk.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thbrk.obj $(libthai_thbrk_OBJS:brk-common.obj=brk-common-test.obj) $(libthai_thwchar_OBJS) $(libthai_thstr_OBJS) $(libthai_thctype_OBJS)
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thwchar.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thwchar.obj $(libthai_thwchar_OBJS) 
+vs$(PDBVER)\$(CFG)\$(PLAT)\test_thwbrk.exe: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\test_thwbrk.obj $(libthai_thwbrk_OBJS) $(libthai_thwchar_OBJS) $(libthai_thbrk_OBJS:brk-common.obj=brk-common-test.obj) $(libthai_thstr_OBJS) $(libthai_thctype_OBJS)
+
+$(libthai_tests_EXES):
+	link $(LDFLAGS) $** $(LIBTHAI_DEP_LIBS) -out:$@
+	@-if exist $@.manifest mt /manifest $@.manifest /outputresource:$@;1
+
+clean:
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\*.exe
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\*.dll
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\*.pdb
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\*.ilk
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\*.lib
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\*.exp
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\thbrk.tri
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\vc$(PDBVER)0.pdb
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests\*.obj
+	@-rd vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests
+	@if exist vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\tdict.txt del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\tdict.txt
+	@if exist vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\thbrk.abm del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\thbrk.abm
+	@if exist vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\ rd vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\vc$(PDBVER)0.pdb
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\thai.def
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\*.obj
+	@-del /f /q vs$(PDBVER)\$(CFG)\$(PLAT)\libthai.pc
+	@-rd vs$(PDBVER)\$(CFG)\$(PLAT)\libthai

--- a/win32/config-msvc.mak.in
+++ b/win32/config-msvc.mak.in
@@ -1,0 +1,35 @@
+# NMake Makefile portion for enabling features for Windows builds
+
+# These are the base minimum libraries required for building libdatrie.
+BASE_INCLUDES = /I$(PREFIX)\include
+
+# Please do not change anything beneath this line unless maintaining the NMake Makefiles
+# Bare minimum features and sources built into libdatrie on Windows
+
+!ifndef LIBDATRIE_INCLUDE_BASE
+LIBDATRIE_INCLUDE_BASE = $(PREFIX)\include
+!endif
+!ifndef LIBDATRIE_LIB
+LIBDATRIE_LIB = datrie.lib
+!endif
+!ifndef TRIETOOL
+TRIETOOL = $(PREFIX)\bin\trietool.exe
+!endif
+
+LIBTHAI_DEP_LIBS = $(LIBDATRIE_LIB)
+
+!if "$(LIBDATRIE_INCLUDE_BASE:/=\)" != "$(PREFIX)\include"
+BASE_INCLUDES = /I$(LIBDATRIE_INCLUDE_BASE) $(BASE_INCLUDES)
+!endif
+
+LIBTHAI_VERSION = @VERSION@
+LIBTHAI_LIBS = vs$(PDBVER)\$(CFG)\$(PLAT)\thai.lib
+LIBTHAI_BASE_CFLAGS = /I..\src /I..\include /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_WARNINGS $(BASE_INCLUDES)
+LIBTHAI_TEST_CFLAGS = /DMSVC_BUILD_LIBTHAI_TESTS $(LIBTHAI_BASE_CFLAGS)
+
+# Disable building trietool.exe if requested
+!ifdef LIB_ONLY
+LIBTHAI_DATA =
+!else
+LIBTHAI_DATA = vs$(PDBVER)\$(CFG)\$(PLAT)\thbrk.tri
+!endif

--- a/win32/create-lists-msvc.mak
+++ b/win32/create-lists-msvc.mak
@@ -1,0 +1,64 @@
+# Convert the source listing to object (.obj) listing in
+# another NMake Makefile module, include it, and clean it up.
+# This is a "fact-of-life" regarding NMake Makefiles...
+# This file does not need to be changed unless one is maintaining the NMake Makefiles
+
+# For those wanting to add things here:
+# To add a list, do the following:
+# # $(description_of_list)
+# if [call create-lists.bat header $(makefile_snippet_file) $(variable_name)]
+# endif
+#
+# if [call create-lists.bat file $(makefile_snippet_file) $(file_name)]
+# endif
+#
+# if [call create-lists.bat footer $(makefile_snippet_file)]
+# endif
+# ... (repeat the if [call ...] lines in the above order if needed)
+# !include $(makefile_snippet_file)
+#
+# (add the following after checking the entries in $(makefile_snippet_file) is correct)
+# (the batch script appends to $(makefile_snippet_file), you will need to clear the file unless the following line is added)
+#!if [del /f /q $(makefile_snippet_file)]
+#!endif
+
+# In order to obtain the .obj filename that is needed for NMake Makefiles to build DLLs/static LIBs or EXEs, do the following
+# instead when doing 'if [call create-lists.bat file $(makefile_snippet_file) $(file_name)]'
+# (repeat if there are multiple $(srcext)'s in $(source_list), ignore any headers):
+# !if [for %c in ($(source_list)) do @if "%~xc" == ".$(srcext)" @call create-lists.bat file $(makefile_snippet_file) $(intdir)\%~nc.obj]
+#
+# $(intdir)\%~nc.obj needs to correspond to the rules added in build-rules-msvc.mak
+# %~xc gives the file extension of a given file, %c in this case, so if %c is a.cc, %~xc means .cc
+# %~nc gives the file name of a given file without extension, %c in this case, so if %c is a.cc, %~nc means a
+
+NULL=
+
+# For libthai
+!if [call create-lists.bat header libthai_objs.mak libthai_OBJS]
+!endif
+
+!if [for %c in (..\src\*.c) do @call create-lists.bat file libthai_objs.mak vs^$(PDBVER)\^$(CFG)\^$(PLAT)\libthai\%~nc.obj]
+!endif
+
+!if [call create-lists.bat footer libthai_objs.mak]
+!endif
+
+!if [for /f %d in ('dir /ad /b ..\src\') do @((call create-lists.bat header libthai_objs.mak libthai_%d_OBJS) & (for %c in (..\src\%d\*.c) do @call create-lists.bat file libthai_objs.mak vs^$(PDBVER^)\^$(CFG^)\^$(PLAT^)\libthai\%~nc.obj) & (call create-lists.bat footer libthai_objs.mak))]
+!endif
+
+!if [echo libthai_dll_OBJS ^= ^$(libthai_OBJS) ^$(libthai_thbrk_OBJS) ^$(libthai_thcell_OBJS) ^$(libthai_thcoll_OBJS) ^$(libthai_thctype_OBJS) ^$(libthai_thinp_OBJS) ^$(libthai_thrend_OBJS) ^$(libthai_thstr_OBJS) ^$(libthai_thwbrk_OBJS) ^$(libthai_thwchar_OBJS) ^$(libthai_thwctype_OBJS) ^$(libthai_thwstr_OBJS)>>libthai_objs.mak]
+!endif
+
+!if [call create-lists.bat header libthai_objs.mak libthai_tests_EXES]
+!endif
+
+!if [for %c in (..\tests\*.c) do @call create-lists.bat file libthai_objs.mak vs^$(PDBVER)\^$(CFG)\^$(PLAT)\%~nc.exe]
+!endif
+
+!if [call create-lists.bat footer libthai_objs.mak]
+!endif
+
+!include libthai_objs.mak
+
+!if [del /f /q libthai_objs.mak]
+!endif

--- a/win32/create-lists.bat
+++ b/win32/create-lists.bat
@@ -1,0 +1,42 @@
+@echo off
+rem Simple .bat script for creating the NMake Makefile snippets.
+
+if not "%1" == "header" if not "%1" == "file" if not "%1" == "footer" goto :error_cmd
+if "%2" == "" goto error_no_destfile
+
+if "%1" == "header" goto :header
+if "%1" == "file" goto :addfile
+if "%1" == "footer" goto :footer
+
+:header
+if "%3" == "" goto error_var
+echo %3 =	\>>%2
+goto done
+
+:addfile
+if "%3" == "" goto error_file
+echo.	%3	\>>%2
+goto done
+
+:footer
+echo.	$(NULL)>>%2
+echo.>>%2
+goto done
+
+:error_cmd
+echo Specified command '%1' was invalid.  Valid commands are: header file footer.
+goto done
+
+:error_no_destfile
+echo Destination NMake snippet file must be specified
+goto done
+
+:error_var
+echo A name must be specified for using '%1'.
+goto done
+
+:error_file
+echo A file must be specified for using '%1'.
+goto done
+
+:done

--- a/win32/create-pc.bat
+++ b/win32/create-pc.bat
@@ -1,0 +1,34 @@
+@echo off
+rem Simple .bat script for creating the NMake Makefile snippets.
+
+if "%1" == "" goto :error_no_dest
+if "%2" == "" goto :error_no_ver
+if "%3" == "" goto :error_dst
+
+set pfx=%~dnp3
+echo prefix=%pfx:\=/%>%1
+echo exec_prefix=^$^{prefix^}>>%1
+echo libdir=^$^{prefix^}/lib>>%1
+echo includedir=^$^{prefix^}/include>>%1
+echo.>>%1
+echo Name: libthai>>%1
+echo Description: Thai support library>>%1
+echo Version: %2>>%1
+echo Requires.private: datrie-0.2>>%1
+echo Libs: -L^$^{libdir^} -lthai>>%1
+echo Cflags: -I^$^{includedir^}>>%1
+goto done
+
+:error_no_dest
+echo No output file specified
+goto done
+
+:error_no_ver
+echo No version specified
+goto done
+
+:error_dst
+echo A prefix path must be specified
+goto done
+
+:done

--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -1,0 +1,150 @@
+# Change this (or specify PREFIX= when invoking this NMake Makefile) if
+# necessary, so that the libs and headers of the dependent third-party
+# libraries can be located.  For instance, if building from GLib's
+# included Visual Studio projects, this should be able to locate the GLib
+# build out-of-the-box if they were not moved.  GLib's headers will be
+# found in $(GLIB_PREFIX)\include\glib-2.0 and
+# $(GLIB_PREFIX)\lib\glib-2.0\include and its import library will be found
+# in $(GLIB_PREFIX)\lib.
+
+!if "$(PREFIX)" == ""
+PREFIX = ..\..\vs$(PDBVER)\$(PLAT)
+!endif
+
+# Location of the PERL interpreter, for running glib-mkenums.  glib-mkenums
+# needs to be found in $(PREFIX)\bin.  Using either a 32-bit or x64 PERL
+# interpreter are supported for either a 32-bit or x64 build.
+
+!if "$(PERL)" == ""
+PERL = perl
+!endif
+
+# Location of the Python interpreter, for building introspection.  The complete set
+# of Python Modules for introspection (the giscanner Python scripts and the _giscanner.pyd
+# compiled module) needs to be found in $(PREFIX)\lib\gobject-introspection\giscanner, and
+# the g-ir-scanner Python script and g-ir-compiler utility program needs to be found
+# in $(PREFIX)\bin, together with any DLLs they will depend on, if those DLLs are not already
+# in your PATH.
+# Note that the Python interpreter and the introspection modules and utility progam must
+# correspond to the build type (i.e. 32-bit Release for 32-bit Release builds, and so on).
+#
+# For introspection, currently only Python 2.7.x is supported.  This may change when Python 3.x
+# support is added upstream in gobject-introspection--when this happens, the _giscanner.pyd must
+# be the one that is built against the release series of Python that is used here.
+
+!if "$(PYTHON)" == ""
+PYTHON = python
+!endif
+
+# Location of the pkg-config utility program, for building introspection.  It needs to be able
+# to find the pkg-config (.pc) files so that the correct libraries and headers for the needed libraries
+# can be located, using PKG_CONFIG_PATH.  Using either a 32-bit or x64 pkg-config are supported for
+# either a 32-bit or x64 build.
+
+!if "$(PKG_CONFIG)" == ""
+PKG_CONFIG = pkg-config
+!endif
+
+# The items below this line should not be changed, unless one is maintaining
+# the NMake Makefiles.  The exception is for the CFLAGS_ADD line(s) where one
+# could use his/her desired compiler optimization flags, if he/she knows what is
+# being done.
+
+# Check to see we are configured to build with MSVC (MSDEVDIR, MSVCDIR or
+# VCINSTALLDIR) or with the MS Platform SDK (MSSDK or WindowsSDKDir)
+!if !defined(VCINSTALLDIR) && !defined(WINDOWSSDKDIR)
+MSG = ^
+This Makefile is only for Visual Studio 2008 and later.^
+You need to ensure that the Visual Studio Environment is properly set up^
+before running this Makefile.
+!error $(MSG)
+!endif
+
+ERRNUL  = 2>NUL
+_HASH=^#
+
+!if ![echo VCVERSION=_MSC_VER > vercl.x] \
+    && ![echo $(_HASH)if defined(_M_IX86) >> vercl.x] \
+    && ![echo PLAT=Win32 >> vercl.x] \
+    && ![echo $(_HASH)elif defined(_M_AMD64) >> vercl.x] \
+    && ![echo PLAT=x64 >> vercl.x] \
+    && ![echo $(_HASH)endif >> vercl.x] \
+    && ![cl -nologo -TC -P vercl.x $(ERRNUL)]
+!include vercl.i
+!if ![echo VCVER= ^\> vercl.vc] \
+    && ![set /a $(VCVERSION) / 100 - 6 >> vercl.vc]
+!include vercl.vc
+!endif
+!endif
+!if ![del $(ERRNUL) /q/f vercl.x vercl.i vercl.vc]
+!endif
+
+!if $(VCVERSION) > 1499 && $(VCVERSION) < 1600
+VSVER = 9
+!elseif $(VCVERSION) > 1599 && $(VCVERSION) < 1700
+VSVER = 10
+!elseif $(VCVERSION) > 1699 && $(VCVERSION) < 1800
+VSVER = 11
+!elseif $(VCVERSION) > 1799 && $(VCVERSION) < 1900
+VSVER = 12
+!elseif $(VCVERSION) > 1899 && $(VCVERSION) < 1910
+VSVER = 14
+!elseif $(VCVERSION) > 1909 && $(VCVERSION) < 1920
+VSVER = 15
+!elseif $(VCVERSION) > 1919 && $(VCVERSION) < 2000
+VSVER = 16
+!else
+VSVER = 0
+!endif
+
+# Visual Studio 2015, 2017 and 2019 link to the vc140 C/C++ runtimes,
+# so we get a vc140.pdb for all these builds.
+!if $(VSVER) < 15
+PDBVER = $(VSVER)
+!else
+PDBVER = 14
+!endif
+
+!if "$(VSVER)" == "0"
+MSG = ^
+This NMake Makefile set supports Visual Studio^
+9 (2008) through 14 (2015).  Your Visual Studio^
+version is not supported.
+!error $(MSG)
+!endif
+
+VALID_CFGSET = FALSE
+!if "$(CFG)" == "release" || "$(CFG)" == "Release" || "$(CFG)" == "debug" || "$(CFG)" == "Debug"
+VALID_CFGSET = TRUE
+!endif
+
+# One may change these items, but be sure to test
+# the resulting binaries
+!if "$(CFG)" == "release" || "$(CFG)" == "Release"
+CFLAGS_ADD = /MD /O2 /GL /MP
+!if "$(VSVER)" != "9"
+CFLAGS_ADD = $(CFLAGS_ADD) /d2Zi+
+!endif
+!else
+CFLAGS_ADD = /MDd /Od
+!endif
+
+!if "$(PLAT)" == "x64"
+LDFLAGS_ARCH = /machine:x64
+!else
+LDFLAGS_ARCH = /machine:x86
+!endif
+
+!if "$(VALID_CFGSET)" == "TRUE"
+CFLAGS = $(CFLAGS_ADD) /W3 /Zi
+
+LDFLAGS_BASE = $(LDFLAGS_ARCH) /libpath:$(PREFIX)\lib /DEBUG
+
+!if "$(CFG)" == "debug" || "$(CFG)" == "Debug"
+ARFLAGS = $(LDFLAGS_ARCH)
+LDFLAGS = $(LDFLAGS_BASE)
+!else
+ARFLAGS = $(LDFLAGS_ARCH) /LTCG
+LDFLAGS = $(LDFLAGS_BASE) /LTCG /opt:ref
+!endif
+!endif

--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -93,13 +93,15 @@ VSVER = 12
 VSVER = 14
 !elseif $(VCVERSION) > 1909 && $(VCVERSION) < 1920
 VSVER = 15
-!elseif $(VCVERSION) > 1919 && $(VCVERSION) < 2000
+!elseif $(VCVERSION) > 1919 && $(VCVERSION) < 1930
 VSVER = 16
+!elseif $(VCVERSION) > 1929 && $(VCVERSION) < 2000
+VSVER = 17
 !else
 VSVER = 0
 !endif
 
-# Visual Studio 2015, 2017 and 2019 link to the vc140 C/C++ runtimes,
+# Visual Studio 2015~2022 link to the vc140 C/C++ runtimes,
 # so we get a vc140.pdb for all these builds.
 !if $(VSVER) < 15
 PDBVER = $(VSVER)
@@ -110,7 +112,7 @@ PDBVER = 14
 !if "$(VSVER)" == "0"
 MSG = ^
 This NMake Makefile set supports Visual Studio^
-9 (2008) through 14 (2015).  Your Visual Studio^
+9 (2008) through 17 (2022).  Your Visual Studio^
 version is not supported.
 !error $(MSG)
 !endif

--- a/win32/detectenv-msvc.mak
+++ b/win32/detectenv-msvc.mak
@@ -68,6 +68,8 @@ _HASH=^#
     && ![echo PLAT=Win32 >> vercl.x] \
     && ![echo $(_HASH)elif defined(_M_AMD64) >> vercl.x] \
     && ![echo PLAT=x64 >> vercl.x] \
+    && ![echo $(_HASH)elif defined(_M_ARM64) >> vercl.x] \
+    && ![echo PLAT=arm64 >> vercl.x] \
     && ![echo $(_HASH)endif >> vercl.x] \
     && ![cl -nologo -TC -P vercl.x $(ERRNUL)]
 !include vercl.i
@@ -131,6 +133,8 @@ CFLAGS_ADD = /MDd /Od
 
 !if "$(PLAT)" == "x64"
 LDFLAGS_ARCH = /machine:x64
+!elseif "$(PLAT)" == "arm64"
+LDFLAGS_ARCH = /machine:arm64
 !else
 LDFLAGS_ARCH = /machine:x86
 !endif

--- a/win32/generate-msvc.mak
+++ b/win32/generate-msvc.mak
@@ -1,0 +1,38 @@
+# NMake Makefile portion for code generation and
+# intermediate build directory creation
+# Items in here should not need to be edited unless
+# one is maintaining the NMake build files.
+
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai\thai.def: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai ..\src\libthai.def
+	@echo Generating $@...
+	@echo EXPORTS>$@
+	@type ..\src\libthai.def>>$@
+
+# Generate compbined Thai Dictionary text file
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\tdict.txt: ..\data\tdict-*.txt
+	@echo Generating $@...
+	@if not exist $(@D) $(MAKE) /f Makefile.vc CFG=$(CFG) $(@D)
+	@for %f in ($**) do @type %f>>$@
+
+# Copy ..\data\thbrk.abm needed to generate Thai dictionary data file
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\thbrk.abm: ..\data\thbrk.abm
+	@echo Copying $**...
+	@if not exist $(@D) $(MAKE) /f Makefile.vc CFG=$(CFG) $(@D)
+	@copy $** $@
+
+# Generate Thai dictionary data file
+vs$(PDBVER)\$(CFG)\$(PLAT)\thbrk.tri: vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\tdict.txt vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\thbrk.abm
+	@echo Generating $@...
+	$(TRIETOOL) -p $(@D)\libthai-data thbrk add-list -e utf-8 vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data\tdict.txt
+	@move $(@D)\libthai-data\$(@F) $@
+
+# Create the build directories
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai	\
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-data	\
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai-tests:
+	@-mkdir $@
+
+# Generate pkg-config files
+vs$(PDBVER)\$(CFG)\$(PLAT)\libthai.pc:
+	@call create-pc.bat $@ $(LIBTHAI_VERSION) $(PREFIX)
+

--- a/win32/info-msvc.mak
+++ b/win32/info-msvc.mak
@@ -1,0 +1,63 @@
+# NMake Makefile portion for displaying config info
+
+THAI_DATA_BUILT = yes
+
+!if "$(LIB_ONLY)" == "1"
+THAI_DATA_BUILT = no
+!endif
+
+!if "$(CFG)" == "release"
+BUILD_TYPE = release
+!else
+BUILD_TYPE = debug
+!endif
+
+build-info-libthai:
+	@echo.
+	@echo =========================
+	@echo Configuration for libthai
+	@echo =========================
+	@echo Thai dictionary data built: $(THAI_DATA_BUILT)
+
+all-build-info: build-info-libthai
+	@echo.
+	@echo ----------------
+	@echo Other build info
+	@echo ----------------
+	@echo Build Type: $(BUILD_TYPE)
+
+help:
+	@echo.
+	@echo ============================
+	@echo Building libthai Using NMake
+	@echo ============================
+	@echo nmake /f Makefile.vc CFG=[release^|debug] ^<PREFIX=PATH^> OPTION=1 ...
+	@echo.
+	@echo Where:
+	@echo ------
+	@echo CFG: Required, use CFG=release for an optimized build and CFG=debug
+	@echo for a debug build.  PDB files are generated for all builds.
+	@echo.
+	@echo PREFIX: Optional, the path where dependent libraries and tools may be
+	@echo found, default is ^$(srcrootdir)\..\vs^$(short_vs_ver)\^$(platform),
+	@echo where ^$(short_vs_ver) is 12 for VS 2013, 14 for VS 2015 and so on; and
+	@echo ^$(platform) is Win32 for 32-bit builds and x64 for x64 builds.
+	@echo.
+	@echo OPTION: Optional, may be any of the following, use OPTION=1 to enable;
+	@echo multiple OPTION's may be used.  If no OPTION is specified, a default
+	@echo libthai is built with Thai dictionary data.  Note that generating Thai
+	@echo dictionary requires trietool.exe from libdatrie, which requires libiconv
+	@echo to run.
+	@echo ======
+	@echo LIB_ONLY:
+	@echo Do not generate Thai dctionary data.  This eliminates the need for trietool.exe.
+	@echo ======
+	@echo A 'clean' target is supported to remove all generated files, intermediate
+	@echo object files and binaries for the specified configuration.
+	@echo.
+	@echo A 'tests' target is supported to build and run the test programs as well.
+	@echo.
+	@echo An 'install' target is supported to copy the build (DLLs, built data,
+	@echo along with LIBs) to appropriate locations under ^$(PREFIX).
+	@echo ======
+	@echo.

--- a/win32/install.mak
+++ b/win32/install.mak
@@ -1,0 +1,16 @@
+# NMake Makefile snippet for copying the built libraries, utilities and headers to
+# a path under $(PREFIX).
+
+install: all
+	@if not exist $(PREFIX)\bin\ mkdir $(PREFIX)\bin
+	@if not exist $(PREFIX)\lib\pkgconfig\ mkdir $(PREFIX)\lib\pkgconfig
+	@if not exist $(PREFIX)\include\thai @mkdir $(PREFIX)\include\thai
+	@copy /b vs$(PDBVER)\$(CFG)\$(PLAT)\thai.dll $(PREFIX)\bin
+	@copy /b vs$(PDBVER)\$(CFG)\$(PLAT)\thai.pdb $(PREFIX)\bin
+	@copy /b vs$(PDBVER)\$(CFG)\$(PLAT)\thai.lib $(PREFIX)\lib
+	@for %f in (..\include\thai\*.h) do @copy %f $(PREFIX)\include\thai\%~nxf
+	@rem Copy the generated pkg-config file
+	@copy /y vs$(PDBVER)\$(CFG)\$(PLAT)\libthai.pc $(PREFIX)\lib\pkgconfig
+	@rem Copy the generated Thai dictionary file, if generated
+	@if exist vs$(PDBVER)\$(CFG)\$(PLAT)\thbrk.tri if not exist $(PREFIX)\share\libthai\ mkdir $(PREFIX)\share\libthai
+	@if exist vs$(PDBVER)\$(CFG)\$(PLAT)\thbrk.tri copy /b vs$(PDBVER)\$(CFG)\$(PLAT)\thbrk.tri $(PREFIX)\share\libthai


### PR DESCRIPTION
Hi,

This attempts to improve Windows support for libthai in the following ways:

*  Make the code buildable on Visual Studio.  Notably make use of DllMain() using DLL_PROCESS_DETACH to make up for the GCC/CLang-only __attribute((destructor)).

*  Do not hardcode the location of thbrk.tri on native Windows (non-Cygwin) builds.  This at least partially fixes issue #7.

*  Add a set of NMake Makefiles that can be used on Visual Studio 2008 and later to build libthai as a DLL with its pkg-config file, with support to build thbrk.tri and to build and run the test programs.

With blessings, thank you!