### PR TITLE
Fix integer truncation in th_{tis2uni,uni2tis}_line

### DIFF
--- a/src/thwchar/thwchar.c
+++ b/src/thwchar/thwchar.c
@@ -27,6 +27,8 @@
 
 #include <thai/thwchar.h>
 
+#include <limits.h>
+
 #define WC_ERR THWCHAR_ERR
 #define TH_ERR THCHAR_ERR
 
@@ -122,18 +124,20 @@ th_tis2uni (thchar_t c)
  * @param  result : buffer for storing resulting Unicode string
  * @param  n      : size of @a result buffer (as number of elements)
  *
- * @return  the length of the output Unicode string
+ * @return the length of the output Unicode string, or INT_MAX, if the result
+ * exceeds the range of @c int, in which case the real result has to computed
+ * by the caller as the lesser of @c{n - 1} and @c{strlen(s)}.
  */
-int
+int /* FIXME: size_t */
 th_tis2uni_line (const thchar_t *s, thwchar_t *result, size_t n)
 {
-    int left = n;
+    size_t left = n;
     while (*s && left > 1) {
         *result++ = th_tis2uni (*s++);
         --left;
     }
     *result = 0;
-    return n - left;
+    return n - left > (size_t)INT_MAX ? INT_MAX : (int)(n - left);
 }
 
 /**
@@ -193,23 +197,24 @@ th_uni2tis (thwchar_t wc)
  * @param  result : buffer for storing resulting TIS-620 string
  * @param  n      : size of @a result buffer (as number of elements)
  *
- * @return  the length of the output TIS-620 string
+ * @return the length of the output TIS-620 string, or INT_MAX, if the result
+ * exceeds the range of @c int, in which case the real result has to computed
+ * by the caller as the lesser of @c{n - 1} and @c{strlen(s)}.
  *
  * Note that, since the conversion is lossy, some characters in the 
  * convesion result may be @c TH_ERR, indicating conversion error.
  */
-int
+int /* FIXME: size_t */
 th_uni2tis_line (const thwchar_t *s, thchar_t *result, size_t n)
 {
-    int left = n;
+    size_t left = n;
     while (*s && left > 1) {
         *result++ = th_uni2tis (*s++);
         --left;
     }
     *result = 0;
-    return n - left;
+    return n - left > (size_t)INT_MAX ? INT_MAX : (int)(n - left);
 }
-
 
 static thchar_t
 uni2thai_ext_ (thwchar_t wc, const thwchar_t rev_map[])


### PR DESCRIPTION
The size_t n parameter was narrowed to an int left variable, which is wrong on 64-bit platforms, as callers expect min(n, strlen(s) + 1) result characters to be written (incl. the terminating NUL), yet, due to the truncation, at most n mod 2^31 characters are written, which may be 0, if n is size_t(INT_MAX) + .

Fix by making the left variable also be of type size_t. This is safe, as each --left is protected by a left > 1 check, so the value can never become negative.

We can't fix the return type, that would be incompatible with existing users, but users don't need the return value: it's easily calculated as min(n - 1, strlen(s)). Add a FIXME comment nonetheless, for when compatibility can be broken, and use saturation arithmetic instead of modular arithmetic to avoid the pseudo-random return value.

Amend the documentation accordingly.