### PR TITLE
WIP: Add meson build

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,51 @@
+dict_dir = get_option('datadir') / 'libthai'
+
+if get_option('dict')
+	sort = find_program('sort')
+	cp = find_program('cp')
+	trietool = find_program('trietool', dirs : datrie.get_variable('bindir'))
+
+	dictionary = custom_target(
+		'tdict',
+		command : [sort, '-u', '-o', '@OUTPUT@', '@INPUT@'],
+		env : {
+			'LC_ALL': 'C',
+		},
+		input : [
+			'tdict-common.txt',
+			'tdict-collection.txt',
+			'tdict-currency.txt',
+			'tdict-district.txt',
+			'tdict-city.txt',
+			'tdict-country.txt',
+			'tdict-geo.txt',
+			'tdict-history.txt',
+			'tdict-ict.txt',
+			'tdict-lang-ethnic.txt',
+			'tdict-proper.txt',
+			'tdict-science.txt',
+			'tdict-slang.txt',
+			'tdict-spell.txt',
+			'tdict-std.txt',
+			'tdict-std-compound.txt'
+		],
+		output : ['tdict.txt'],
+	)
+	# trietool look for thbrk.abm in the directory of thbrk.tri
+	# so we need to copy thbrk.abm into the build directory
+	alphamap = custom_target(
+		'alphabet_map',
+		command : [cp, '@INPUT@', '@OUTPUT@'],
+		input : ['thbrk.abm'],
+		output : ['thbrk.abm'],
+	)
+	tri = custom_target(
+		'tri',
+		command : [trietool, 'data/thbrk', 'add-list', '-e', 'utf-8', '@INPUT0@'],
+		input : [dictionary],
+		depends : [alphamap],
+		output : ['thbrk.tri'],
+		install : true,
+		install_dir: dict_dir,
+	)
+endif

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,7 +3,7 @@ dict_dir = get_option('datadir') / 'libthai'
 if get_option('dict')
 	sort = find_program('sort')
 	cp = find_program('cp')
-	trietool = find_program('trietool', dirs : datrie.get_variable('bindir'))
+	trietool = find_program('trietool')
 
 	dictionary = custom_target(
 		'tdict',

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,22 @@
+install_headers(
+	'thai/thailib.h',
+	'thai/thctype.h',
+	'thai/thstr.h',
+	'thai/thcoll.h',
+	'thai/thcell.h',
+	'thai/thinp.h',
+	'thai/thrend.h',
+	'thai/thbrk.h',
+	'thai/thwchar.h',
+	'thai/thwctype.h',
+	'thai/thwcoll.h',
+	'thai/thwinp.h',
+	'thai/thwrend.h',
+	'thai/thwstr.h',
+	'thai/thwbrk.h',
+	'thai/tis.h',
+	'thai/wtt.h',
+	subdir : 'thai',
+)
+
+include_dir = include_directories('.')

--- a/man/meson.build
+++ b/man/meson.build
@@ -1,0 +1,5 @@
+install_man(
+	'man3/libthai.3',
+	'man3/thctype.3',
+	'man3/wtt.3',
+)

--- a/meson.build
+++ b/meson.build
@@ -9,9 +9,6 @@ project(
 sh = find_program('sh')
 compiler = meson.get_compiler('c')
 datrie = dependency('datrie-0.2')
-deps = [
-    datrie,
-]
 
 version = run_command(files('build-aux/git-version-gen'), check : true).stdout().strip()
 meson.add_dist_script(sh, '-c', 'echo "@0@" > "$MESON_DIST_ROOT/VERSION"'.format(version))

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,43 @@
+project(
+    'libthai', 'c', meson_version : '>=1.0.0',
+    version: run_command(files('build-aux/git-version-gen'), check : true).stdout().strip()
+)
+
+# --enable-ansi: Removed. C compiler with Meson should be quite mature now
+# --enable-debug: Replaced with Meson --buildtype=debug
+
+sh = find_program('sh')
+compiler = meson.get_compiler('c')
+datrie = dependency('datrie-0.2')
+deps = [
+    datrie,
+]
+
+version = run_command(files('build-aux/git-version-gen'), check : true).stdout().strip()
+meson.add_dist_script(sh, '-c', 'echo "@0@" > "$MESON_DIST_ROOT/VERSION"'.format(version))
+meson.add_dist_script(sh, '-c', 'cd "$MESON_DIST_ROOT" && ./autogen.sh')
+meson.add_dist_script(sh, '-c', 'cd "$MESON_DIST_ROOT" && rm -r autom4te.cache autogen.sh || true')
+
+LT_CURRENT = 3
+LT_REVISION = 1
+LT_AGE = 3
+
+soversion = LT_CURRENT - LT_AGE
+libversion = '@0@.@1@.@2@'.format(soversion, LT_AGE, LT_REVISION)
+
+# Detect for version-script support
+ld_has_version_script = compiler.has_link_argument(
+    '-Wl,-version-script,@0@'.format(meson.global_source_root() / 'build-aux' / 'test.map')
+)
+
+if get_option('buildtype') in ['debug', 'debugoptimized']
+    add_project_arguments('-DNDEBUG', language : ['c'])
+endif
+
+# TODO: Doxygen
+
+subdir('data')
+subdir('include')
+subdir('src')
+subdir('man')
+subdir('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('docs', type : 'feature', value : 'auto', description : 'Generate documents with Doxygen')
+option('docsdir', type : 'string', value : 'share/doc/datrie', description : 'Where to install the Doxygen-generated HTML doc')
+option('dict', type : 'boolean', value : true, description : 'Enable dictionary data generation (require libdatrie)')

--- a/src/meson.build
+++ b/src/meson.build
@@ -57,6 +57,10 @@ thai = library(
 	soversion : soversion,
 	include_directories : include_dir,
 )
+libthai_dep = declare_dependency(
+	include_directories : include_dir,
+	link_with : thai,
+)
 
 pkg = import('pkgconfig')
 pkg.generate(
@@ -65,5 +69,5 @@ pkg.generate(
 	name : 'libthai',
 	description : 'Thai support library',
 	version : version,
-	requires_private: datrie,
+	requires_private: ['datrie-0.2'],
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,69 @@
+ldflags = []
+link_depends = ['libthai.map']
+
+if ld_has_version_script
+	ldflags += [
+		'-Wl,--version-script,@0@'.format(meson.current_source_dir() / 'libthai.map')
+	]
+else
+	ldflags += [
+		'-export-symbols @0@'.format(meson.current_source_dir() / 'libthai.map')
+	]
+endif
+
+thai = library(
+	'thai',
+	[
+		'thctype/thctype.c',
+		'thctype/wtt.c',
+
+		'thstr/thstr.c',
+
+		'thcell/thcell.c',
+
+		'thinp/thinp.c',
+
+		'thrend/thrend.c',
+
+		'thcoll/cweight.c',
+		'thcoll/cweight.h',
+		'thcoll/thcoll.c',
+
+		'thbrk/thbrk.c',
+		'thbrk/thbrk-priv.h',
+		'thbrk/thbrk-utils.h',
+		'thbrk/brk-ctype.c',
+		'thbrk/brk-ctype.h',
+		'thbrk/brk-common.c',
+		'thbrk/brk-common.h',
+		'thbrk/brk-maximal.c',
+		'thbrk/brk-maximal.h',
+
+		'thwchar/thwchar.c',
+
+		'thwctype/thwctype.c',
+
+		'thwstr/thwstr.c',
+
+		'thwbrk/thwbrk.c',
+	],
+
+	install : true,
+	link_args : ldflags,
+	link_depends : link_depends,
+	c_args: ['-DDICT_DIR="@0@"'.format(dict_dir)],
+	dependencies : [datrie],
+	version : libversion,
+	soversion : soversion,
+	include_directories : include_dir,
+)
+
+pkg = import('pkgconfig')
+pkg.generate(
+	thai,
+	filebase : 'libthai',
+	name : 'libthai',
+	description : 'Thai support library',
+	version : version,
+	requires_private: datrie,
+)

--- a/subprojects/libdatrie.wrap
+++ b/subprojects/libdatrie.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/tlwg/libdatrie.git
+revision = daa9c6d33ef95931a0796294f005f249af97cc05
+depth = 1
+
+[provide]
+dependency_names = datrie-0.2
+program_names = trietool

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,41 @@
+fs = import('fs')
+
+tests = [
+	'thctype', 'thcell', 'thinp', 'thrend',
+	'thstr', 'thwchar',
+]
+
+foreach item : tests
+	exe = executable(
+		'test_' + item,
+		'test_@0@.c'.format(item),
+		link_with : thai,
+	)
+	test(item, exe)
+endforeach
+
+# thcoll
+thsort = executable('thsort', 'thsort.c', link_with : thai)
+test(
+	'thcoll',
+	find_program('test-thcoll.sh'),
+	depends : [thsort],
+	env : {
+		'srcdir' : meson.current_source_dir(),
+		'top_builddir' : meson.project_build_root(),
+	},
+)
+
+if get_option('dict')
+	foreach item : ['thbrk', 'thwbrk']
+		exe = executable('test_' + item, 'test_@0@.c'.format(item), link_with : thai)
+		test(
+			item,
+			exe,
+			depends : [tri],
+			env : {
+				'LIBTHAI_DICTDIR' : fs.parent(tri.full_path()),
+			},
+		)
+	endforeach
+endif


### PR DESCRIPTION
This PR add Meson build for libthai

Notable changes:

- Configure options `--enable-ansi` is removed, as modern compilers should be quite mature now
- Configure options `--enable-debug` is replaced by `--buildtype=debug`
- This do not build each sub libraries then merge into one large library, instead all source is built all at once. I believe the old setup was done for incremental compiling, which Meson should already have done that.
- `test-th*brk.sh` are no longer used as it only wrap the actual test with env, which is a Meson feature. (`test-thcoll.sh` is still used)
- This contains wrapfile for https://github.com/tlwg/libdatrie/pull/22 which points to my last commit. If the build environment do not have datrie installed, Meson will download and build Datrie automatically.

TODO:

- Doxygen build
- Test archive building