### PR TITLE
Fix infinite try when dict is missing

### DIFF
--- a/src/thbrk/thbrk.c
+++ b/src/thbrk/thbrk.c
@@ -347,6 +347,7 @@ brk_get_shared_brk ()
 
     if (UNLIKELY (!brk_shared_brk && !is_tried)) {
         brk_shared_brk = th_brk_new (NULL);
+        is_tried = 1;
     }
 
     return brk_shared_brk;


### PR DESCRIPTION
`is_tried` was set to `0` but never get updated.
So `brk_get_shared_brk()` keeps trying (and likely failed again over an over).

This PR proposed that, if failed loading once, it should stop trying.
This is done by set `is_tried` to `1`.



