### PR TITLE
Add dynamic path resolution for Windows

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,7 +30,7 @@ EXPORTS_FLAGS = -export-symbols $(srcdir)/libthai.def
 EXPORTS_DEPS = libthai.def
 endif
 
-libthai_la_SOURCES = libthai.c
+libthai_la_SOURCES = libthai.c utils/win-utils.c
 libthai_la_LIBADD = $(libthai_sublibs)
 libthai_la_LDFLAGS = -no-undefined \
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,8 @@ libthai_sublibs = \
 	$(top_builddir)/src/thwchar/libthwchar.la \
 	$(top_builddir)/src/thwctype/libthwctype.la \
 	$(top_builddir)/src/thwstr/libthwstr.la \
-	$(top_builddir)/src/thwbrk/libthwbrk.la 
+	$(top_builddir)/src/thwbrk/libthwbrk.la \
+	$(top_builddir)/src/utils/libutils.la
 
 if LD_HAS_VERSION_SCRIPT
 EXPORTS_FLAGS = -Wl,-version-script -Wl,$(srcdir)/libthai.map
@@ -30,7 +31,7 @@ EXPORTS_FLAGS = -export-symbols $(srcdir)/libthai.def
 EXPORTS_DEPS = libthai.def
 endif
 
-libthai_la_SOURCES = libthai.c utils/win-utils.c
+libthai_la_SOURCES = libthai.c
 libthai_la_LIBADD = $(libthai_sublibs)
 libthai_la_LDFLAGS = -no-undefined \
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -107,6 +107,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         case DLL_PROCESS_ATTACH:
             libthai_dll = hinstDLL;
             break;
+        case DLL_PROCESS_DETACH:
+            brk_free_shared_brk ();
+            break;
     }
     return TRUE;
 }

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -117,7 +117,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 }
 
 wchar_t *
-th_get_win32_installdir_w (void)
+win_inst_dir (void)
 {
     /* Windows stores filenames natively as UTF-16 */
     wchar_t *path;

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -116,12 +116,62 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     return TRUE;
 }
 
+/* Reverse search for needle in the first n wchar_t of haystack; NULL if absent. */
+static const wchar_t *
+wmemrchr_bound (const wchar_t *haystack, wchar_t needle, size_t n)
+{
+    const wchar_t *p;
+    for (p = haystack + n - 1; p >= haystack; --p) {
+        if (*p == needle)
+            return p;
+    }
+    return NULL;
+}
+
+/* Install dir = parent of nearest "bin"/"lib" ancestor, else path's own dir.
+ * C:\Program Files\App\bin\libthai.dll -> C:\Program Files\App
+ * C:\Program Files\App\libthai.dll     -> C:\Program Files\App
+ */
+static wchar_t *
+win_find_inst_dir (const wchar_t *filepath)
+{
+    size_t n = wcslen (filepath);
+    const wchar_t *base_end = NULL;
+    size_t len;
+    wchar_t *result;
+
+    for (;;) {
+        const wchar_t *p = wmemrchr_bound (filepath, L'\\', n);
+        if (!p)
+            break;
+        if (_wcsnicmp (p + 1, L"bin\\", 4) == 0 ||
+            _wcsnicmp (p + 1, L"lib\\", 4) == 0) {
+            base_end = p;
+            break;
+        }
+        n = (size_t) (p - filepath);
+    }
+
+    if (!base_end) {
+        const wchar_t *p = wcsrchr (filepath, L'\\');
+        base_end = p ? p : filepath;
+    }
+
+    len = (size_t) (base_end - filepath);
+    result = (wchar_t *) malloc ((len + 1) * sizeof (wchar_t));
+    if (!result)
+        return NULL;
+    wmemcpy (result, filepath, len);
+    result[len] = L'\0';
+    return result;
+}
+
 wchar_t *
 win_inst_dir (void)
 {
     /* Windows stores filenames natively as UTF-16 */
     wchar_t *path;
-    wchar_t *seg_end, *found;
+    wchar_t *dir;
     DWORD len;
 
     if (!libthai_dll)
@@ -137,42 +187,9 @@ win_inst_dir (void)
         return NULL;
     }
 
-    /* Directory of the DLL */
-    {
-        wchar_t *p = wcsrchr (path, L'\\');
-        if (p)
-            *p = L'\0';
-    }
-
-    /* Find nearest "bin"/"lib" dir at or above the DLL;
-     * installdir is its parent, else the DLL's own directory.
-     * C:\Program Files\App\bin\libthai.dll -> C:\Program Files\App
-     * C:\Program Files\App\libthai.dll     -> C:\Program Files\App
-     */
-    found = NULL;
-    seg_end = path + wcslen (path);
-    while (seg_end > path) {
-        wchar_t *seg_start = seg_end;
-        size_t seg_len;
-
-        while (seg_start > path && seg_start[-1] != L'\\')
-            seg_start--;
-
-        seg_len = (size_t) (seg_end - seg_start);
-        if (seg_start > path && seg_len == 3 &&
-            (_wcsnicmp (seg_start, L"bin", 3) == 0 ||
-             _wcsnicmp (seg_start, L"lib", 3) == 0)) {
-            found = seg_start - 1;
-            break;
-        }
-
-        seg_end = (seg_start > path) ? seg_start - 1 : path;
-    }
-
-    if (found)
-        *found = L'\0';
-
-    return path;
+    dir = win_find_inst_dir (path);
+    free (path);
+    return dir;
 }
 #endif /* _WIN32 && !__CYGWIN__ */
 

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -119,6 +119,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 wchar_t *
 th_get_win32_installdir_w (void)
 {
+    /* Windows stores filenames natively as UTF-16 */
     wchar_t *path;
     wchar_t *seg_end, *found;
     DWORD len;
@@ -143,8 +144,11 @@ th_get_win32_installdir_w (void)
             *p = L'\0';
     }
 
-    /* Walk up to the nearest "bin"/"lib" ancestor;
-     * fall back to the DLL's own directory if none found. */
+    /* Find nearest "bin"/"lib" dir at or above the DLL;
+     * installdir is its parent, else the DLL's own directory.
+     * C:\Program Files\App\bin\libthai.dll -> C:\Program Files\App
+     * C:\Program Files\App\libthai.dll     -> C:\Program Files\App
+     */
     found = NULL;
     seg_end = path + wcslen (path);
     while (seg_end > path) {

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -112,7 +112,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 }
 
 char *
-libthai_get_installdir (void)
+th_get_win32_installdir (void)
 {
     wchar_t wc_fn[MAX_PATH];
     char *filename = NULL;

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -99,6 +99,8 @@
 
 static HMODULE libthai_dll = NULL;
 
+void _libthai_on_unload (void);
+
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved);
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
@@ -108,7 +110,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
             libthai_dll = hinstDLL;
             break;
         case DLL_PROCESS_DETACH:
-            brk_free_shared_brk ();
+            _libthai_on_unload ();
             break;
     }
     return TRUE;

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -97,30 +97,31 @@
 #include <stdlib.h>
 #include <wchar.h>
 
-static HMODULE libthai_dll = NULL;
-
 void _libthai_on_unload (void);
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved);
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
-    switch (fdwReason) {
-        case DLL_PROCESS_ATTACH:
-            libthai_dll = hinstDLL;
-            break;
-        case DLL_PROCESS_DETACH:
+    (void) hinstDLL;
+    if (fdwReason == DLL_PROCESS_DETACH) {
+        /* Skip cleanup if the whole process is exiting (lpvReserved != NULL);
+         * other DLLs may already be gone */
+        if (!lpvReserved)
             _libthai_on_unload ();
-            break;
     }
     return TRUE;
 }
 
-/* Reverse search for needle in the first n wchar_t of haystack; NULL if absent. */
+/* Reverse search for needle in the first n wchar_t of haystack;
+ * NULL if absent.
+ */
 static const wchar_t *
 wmemrchr_bound (const wchar_t *haystack, wchar_t needle, size_t n)
 {
     const wchar_t *p;
+    if (n == 0)
+        return NULL;
     for (p = haystack + n - 1; p >= haystack; --p) {
         if (*p == needle)
             return p;
@@ -128,7 +129,16 @@ wmemrchr_bound (const wchar_t *haystack, wchar_t needle, size_t n)
     return NULL;
 }
 
-/* Install dir = parent of nearest "bin"/"lib" ancestor, else path's own dir.
+/* True if s starts with marker (case-insensitively) followed by '\\'. */
+static int
+segment_matches (const wchar_t *s, const wchar_t *marker)
+{
+    size_t len = wcslen (marker);
+    return _wcsnicmp (s, marker, len) == 0 && s[len] == L'\\';
+}
+
+/* Install dir = parent of nearest "bin"/"lib"/"bin64"/"lib64" ancestor,
+ * else path's own dir.
  * C:\Program Files\App\bin\libthai.dll -> C:\Program Files\App
  * C:\Program Files\App\libthai.dll     -> C:\Program Files\App
  */
@@ -140,13 +150,15 @@ win_find_inst_dir (const wchar_t *filepath)
     size_t len;
     wchar_t *result;
 
-    /* Scan segments right-to-left for \bin\ or \lib\ */
+    /* Scan segments right-to-left for a known install-layout marker dir */
     for (;;) {
         const wchar_t *p = wmemrchr_bound (filepath, L'\\', n);
         if (!p)
             break;
-        if (_wcsnicmp (p + 1, L"bin\\", 4) == 0 ||
-            _wcsnicmp (p + 1, L"lib\\", 4) == 0) {
+        if (segment_matches (p + 1, L"bin") ||
+            segment_matches (p + 1, L"lib") ||
+            segment_matches (p + 1, L"bin64") ||
+            segment_matches (p + 1, L"lib64")) {
             base_end = p;
             break;
         }
@@ -171,31 +183,40 @@ win_find_inst_dir (const wchar_t *filepath)
 wchar_t *
 win_inst_dir (void)
 {
-    /* Windows stores filenames natively as UTF-16 */
+    /* Windows stores paths natively as UTF-16 */
+    /* Cached: the install dir is invariant for the process's life. */
+    static wchar_t *cached_dir = NULL;
+    static int computed = 0;
+    HMODULE hmod = NULL;
     wchar_t *path;
-    wchar_t *dir;
     DWORD len;
 
-    if (!libthai_dll)
+    if (computed)
+        return cached_dir;
+    computed = 1;
+
+    if (!GetModuleHandleExW (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                              (LPCWSTR) &win_inst_dir, &hmod))
         return NULL;
 
     path = (wchar_t *) malloc (MAX_PATH * sizeof (wchar_t));
     if (!path)
         return NULL;
 
-    len = GetModuleFileNameW (libthai_dll, path, MAX_PATH);
+    len = GetModuleFileNameW (hmod, path, MAX_PATH);
     if (len == 0 || len >= MAX_PATH) {
         free (path);
         return NULL;
     }
 
-    dir = win_find_inst_dir (path);
+    cached_dir = win_find_inst_dir (path);
     free (path);
-    return dir;
+    return cached_dir;
 }
 #endif /* _WIN32 && !__CYGWIN__ */
 
-#if defined (__GNUC__) || defined (__clang__)
+#if (defined (__GNUC__) || defined (__clang__)) && \
+    !(defined (_WIN32) && !defined (__CYGWIN__))
 __attribute__ ((destructor))
 #endif
 void

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -95,7 +95,7 @@
 #define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
 #include <stdlib.h>
-#include <string.h>
+#include <wchar.h>
 
 static HMODULE libthai_dll = NULL;
 
@@ -116,57 +116,59 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     return TRUE;
 }
 
-char *
-th_get_win32_installdir (void)
+wchar_t *
+th_get_win32_installdir_w (void)
 {
-    wchar_t wc_fn[MAX_PATH];
-    char *filename = NULL;
-    char *retval = NULL;
-    char *p;
-    int len;
+    wchar_t *path;
+    wchar_t *seg_end, *found;
+    DWORD len;
 
     if (!libthai_dll)
         return NULL;
 
-    if (!GetModuleFileNameW (libthai_dll, wc_fn, MAX_PATH))
+    path = (wchar_t *) malloc (MAX_PATH * sizeof (wchar_t));
+    if (!path)
         return NULL;
 
-    len = WideCharToMultiByte (CP_UTF8, 0, wc_fn, -1, NULL, 0, NULL, NULL);
-    if (len <= 0)
+    len = GetModuleFileNameW (libthai_dll, path, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH) {
+        free (path);
         return NULL;
-
-    filename = (char *) malloc (len);
-    if (!filename)
-        return NULL;
-
-    WideCharToMultiByte (CP_UTF8, 0, wc_fn, -1, filename, len, NULL, NULL);
-
-    if ((p = strrchr (filename, '\\')) != NULL)
-        *p = '\0';
-
-    retval = (char *) malloc (strlen (filename) + 1);
-    if (retval)
-        strcpy (retval, filename);
-
-    do {
-        p = strrchr (retval, '\\');
-        if (p == NULL)
-            break;
-
-        *p = '\0';
-
-        if (_stricmp (p + 1, "bin") == 0 || _stricmp (p + 1, "lib") == 0)
-            break;
-    } while (p != NULL);
-
-    if (p == NULL) {
-        free (retval);
-        retval = filename;
-    } else {
-        free (filename);
     }
 
-    return retval;
+    /* Directory of the DLL */
+    {
+        wchar_t *p = wcsrchr (path, L'\\');
+        if (p)
+            *p = L'\0';
+    }
+
+    /* Walk up to the nearest "bin"/"lib" ancestor;
+     * fall back to the DLL's own directory if none found. */
+    found = NULL;
+    seg_end = path + wcslen (path);
+    while (seg_end > path) {
+        wchar_t *seg_start = seg_end;
+        size_t seg_len;
+
+        while (seg_start > path && seg_start[-1] != L'\\')
+            seg_start--;
+
+        seg_len = (size_t) (seg_end - seg_start);
+        if (seg_start > path && seg_len == 3 &&
+            (_wcsnicmp (seg_start, L"bin", 3) == 0 ||
+             _wcsnicmp (seg_start, L"lib", 3) == 0)) {
+            found = seg_start - 1;
+            break;
+        }
+
+        seg_end = (seg_start > path) ? seg_start - 1 : path;
+    }
+
+    if (found)
+        *found = L'\0';
+
+    return path;
 }
 #endif /* _WIN32 && !__CYGWIN__ */
 

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -89,8 +89,86 @@
  */
 
 #include "thbrk/thbrk-priv.h"
+#include "utils/priv-utils.h"
 
-__attribute__ ((destructor)) void
+#if defined (_WIN32) && !defined (__CYGWIN__)
+#define WIN32_LEAN_AND_MEAN 1
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+
+static HMODULE libthai_dll = NULL;
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved);
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    switch (fdwReason) {
+        case DLL_PROCESS_ATTACH:
+            libthai_dll = hinstDLL;
+            break;
+    }
+    return TRUE;
+}
+
+char *
+libthai_get_installdir (void)
+{
+    wchar_t wc_fn[MAX_PATH];
+    char *filename = NULL;
+    char *retval = NULL;
+    char *p;
+    int len;
+
+    if (!libthai_dll)
+        return NULL;
+
+    if (!GetModuleFileNameW (libthai_dll, wc_fn, MAX_PATH))
+        return NULL;
+
+    len = WideCharToMultiByte (CP_UTF8, 0, wc_fn, -1, NULL, 0, NULL, NULL);
+    if (len <= 0)
+        return NULL;
+
+    filename = (char *) malloc (len);
+    if (!filename)
+        return NULL;
+
+    WideCharToMultiByte (CP_UTF8, 0, wc_fn, -1, filename, len, NULL, NULL);
+
+    if ((p = strrchr (filename, '\\')) != NULL)
+        *p = '\0';
+
+    retval = (char *) malloc (strlen (filename) + 1);
+    if (retval)
+        strcpy (retval, filename);
+
+    do {
+        p = strrchr (retval, '\\');
+        if (p == NULL)
+            break;
+
+        *p = '\0';
+
+        if (_stricmp (p + 1, "bin") == 0 || _stricmp (p + 1, "lib") == 0)
+            break;
+    } while (p != NULL);
+
+    if (p == NULL) {
+        free (retval);
+        retval = filename;
+    } else {
+        free (filename);
+    }
+
+    return retval;
+}
+#endif /* _WIN32 && !__CYGWIN__ */
+
+#if defined (__GNUC__) || defined (__clang__)
+__attribute__ ((destructor))
+#endif
+void
 _libthai_on_unload ()
 {
     brk_free_shared_brk ();

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -140,6 +140,7 @@ win_find_inst_dir (const wchar_t *filepath)
     size_t len;
     wchar_t *result;
 
+    /* Scan segments right-to-left for \bin\ or \lib\ */
     for (;;) {
         const wchar_t *p = wmemrchr_bound (filepath, L'\\', n);
         if (!p)
@@ -152,6 +153,7 @@ win_find_inst_dir (const wchar_t *filepath)
         n = (size_t) (p - filepath);
     }
 
+    /* Not found: fall back to the DLL's own directory */
     if (!base_end) {
         const wchar_t *p = wcsrchr (filepath, L'\\');
         base_end = p ? p : filepath;

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -91,130 +91,6 @@
 #include "thbrk/thbrk-priv.h"
 #include "utils/priv-utils.h"
 
-#if defined (_WIN32) && !defined (__CYGWIN__)
-#define WIN32_LEAN_AND_MEAN 1
-#include <windows.h>
-#include <stdlib.h>
-#include <wchar.h>
-
-void _libthai_on_unload (void);
-
-BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved);
-
-BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
-{
-    (void) hinstDLL;
-    if (fdwReason == DLL_PROCESS_DETACH) {
-        /* Skip cleanup if the whole process is exiting (lpvReserved != NULL);
-         * other DLLs may already be gone */
-        if (!lpvReserved)
-            _libthai_on_unload ();
-    }
-    return TRUE;
-}
-
-/* Reverse search for needle in the first n wchar_t of haystack;
- * NULL if absent.
- */
-static const wchar_t *
-wmemrchr_bound (const wchar_t *haystack, wchar_t needle, size_t n)
-{
-    const wchar_t *p;
-    if (n == 0)
-        return NULL;
-    for (p = haystack + n - 1; p >= haystack; --p) {
-        if (*p == needle)
-            return p;
-    }
-    return NULL;
-}
-
-/* True if s starts with marker (case-insensitively) followed by '\\'. */
-static int
-segment_matches (const wchar_t *s, const wchar_t *marker)
-{
-    size_t len = wcslen (marker);
-    return _wcsnicmp (s, marker, len) == 0 && s[len] == L'\\';
-}
-
-/* Install dir = parent of nearest "bin"/"lib"/"bin64"/"lib64" ancestor,
- * else path's own dir.
- * C:\Program Files\App\bin\libthai.dll -> C:\Program Files\App
- * C:\Program Files\App\libthai.dll     -> C:\Program Files\App
- */
-static wchar_t *
-win_find_inst_dir (const wchar_t *filepath)
-{
-    size_t n = wcslen (filepath);
-    const wchar_t *base_end = NULL;
-    size_t len;
-    wchar_t *result;
-
-    /* Scan segments right-to-left for a known install-layout marker dir */
-    for (;;) {
-        const wchar_t *p = wmemrchr_bound (filepath, L'\\', n);
-        if (!p)
-            break;
-        if (segment_matches (p + 1, L"bin") ||
-            segment_matches (p + 1, L"lib") ||
-            segment_matches (p + 1, L"bin64") ||
-            segment_matches (p + 1, L"lib64")) {
-            base_end = p;
-            break;
-        }
-        n = (size_t) (p - filepath);
-    }
-
-    /* Not found: fall back to the DLL's own directory */
-    if (!base_end) {
-        const wchar_t *p = wcsrchr (filepath, L'\\');
-        base_end = p ? p : filepath;
-    }
-
-    len = (size_t) (base_end - filepath);
-    result = (wchar_t *) malloc ((len + 1) * sizeof (wchar_t));
-    if (!result)
-        return NULL;
-    wmemcpy (result, filepath, len);
-    result[len] = L'\0';
-    return result;
-}
-
-wchar_t *
-win_inst_dir (void)
-{
-    /* Windows stores paths natively as UTF-16 */
-    /* Cached: the install dir is invariant for the process's life. */
-    static wchar_t *cached_dir = NULL;
-    static int computed = 0;
-    HMODULE hmod = NULL;
-    wchar_t *path;
-    DWORD len;
-
-    if (computed)
-        return cached_dir;
-    computed = 1;
-
-    if (!GetModuleHandleExW (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                              (LPCWSTR) &win_inst_dir, &hmod))
-        return NULL;
-
-    path = (wchar_t *) malloc (MAX_PATH * sizeof (wchar_t));
-    if (!path)
-        return NULL;
-
-    len = GetModuleFileNameW (hmod, path, MAX_PATH);
-    if (len == 0 || len >= MAX_PATH) {
-        free (path);
-        return NULL;
-    }
-
-    cached_dir = win_find_inst_dir (path);
-    free (path);
-    return cached_dir;
-}
-#endif /* _WIN32 && !__CYGWIN__ */
-
 #if (defined (__GNUC__) || defined (__clang__)) && \
     !(defined (_WIN32) && !defined (__CYGWIN__))
 __attribute__ ((destructor))
@@ -223,6 +99,9 @@ void
 _libthai_on_unload ()
 {
     brk_free_shared_brk ();
+#if defined (_WIN32) && !defined (__CYGWIN__)
+    win_inst_dir_free ();
+#endif
 }
 
 /*

--- a/src/libthai.c
+++ b/src/libthai.c
@@ -89,7 +89,7 @@
  */
 
 #include "thbrk/thbrk-priv.h"
-#include "utils/priv-utils.h"
+#include "utils/win-utils.h"
 
 #if (defined (__GNUC__) || defined (__clang__)) && \
     !(defined (_WIN32) && !defined (__CYGWIN__))

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -33,6 +33,13 @@
 #include "utils/priv-utils.h"
 #include "brk-common.h"
 
+#if defined (_WIN32) && !defined (__CYGWIN__)
+#include <wchar.h>
+/* turns a narrow string-literal macro into a wide one, e.g. WIDEN (DICT_NAME) */
+#define WIDEN_(s) L ## s
+#define WIDEN(s) WIDEN_(s)
+#endif
+
 #define DICT_NAME   "thbrk"
 
 static char *
@@ -65,18 +72,26 @@ brk_load_default_dict ()
     /* Then, fall back to default DICT_DIR macro */
     if (!dict_trie) {
 #if defined (_WIN32) && !defined (__CYGWIN__)
-        char *basedir = th_get_win32_installdir ();
+        wchar_t *basedir = th_get_win32_installdir_w ();
         if (basedir) {
-            const char *sharedir = "share\\libthai\\" DICT_NAME ".tri";
-            size_t total_len = strlen (basedir) + strlen (sharedir) + 1; /* '+ 1' for '\\' */
-            char *filepath = (char *) malloc (total_len + 1);
+            static const wchar_t sharedir[] =
+                L"share\\libthai\\" WIDEN (DICT_NAME) L".tri";
+            size_t total_len = wcslen (basedir) + 1 /* '\\' */
+                              + (sizeof (sharedir) / sizeof (wchar_t));
+            wchar_t *filepath = (wchar_t *) malloc (total_len * sizeof (wchar_t));
             if (filepath) {
-                sprintf (filepath, "%s\\%s", basedir, sharedir);
-                dict_trie = trie_new_from_file (filepath);
+                swprintf (filepath, total_len, L"%ls\\%ls", basedir, sharedir);
+                FILE *f = _wfopen (filepath, L"rb");
+                if (f) {
+                    dict_trie = trie_fread (f);
+                    fclose (f);
+                }
                 free (filepath);
             }
             free (basedir);
         }
+        if (!dict_trie)
+            dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
 #else
         dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
 #endif

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -64,7 +64,22 @@ brk_load_default_dict ()
 
     /* Then, fall back to default DICT_DIR macro */
     if (!dict_trie) {
+#if defined (_WIN32) && !defined (__CYGWIN__)
+        char *basedir = libthai_get_installdir ();
+        if (basedir) {
+            const char *sharedir = "share\\libthai\\" DICT_NAME ".tri";
+            size_t total_len = strlen (basedir) + strlen (sharedir) + 1; /* '+ 1' for '\\' */
+            char *filepath = (char *) malloc (total_len + 1);
+            if (filepath) {
+                sprintf (filepath, "%s\\%s", basedir, sharedir);
+                dict_trie = trie_new_from_file (filepath);
+                free (filepath);
+            }
+            free (basedir);
+        }
+#else
         dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
+#endif
     }
 
     return dict_trie;

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -65,7 +65,7 @@ brk_load_default_dict ()
     /* Then, fall back to default DICT_DIR macro */
     if (!dict_trie) {
 #if defined (_WIN32) && !defined (__CYGWIN__)
-        char *basedir = libthai_get_installdir ();
+        char *basedir = th_get_win32_installdir ();
         if (basedir) {
             const char *sharedir = "share\\libthai\\" DICT_NAME ".tri";
             size_t total_len = strlen (basedir) + strlen (sharedir) + 1; /* '+ 1' for '\\' */

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -72,7 +72,7 @@ brk_load_default_dict ()
     /* Then, fall back to default DICT_DIR macro */
     if (!dict_trie) {
 #if defined (_WIN32) && !defined (__CYGWIN__)
-        wchar_t *basedir = th_get_win32_installdir_w ();
+        wchar_t *basedir = win_inst_dir ();
         if (basedir) {
             static const wchar_t sharedir[] =
                 L"share\\libthai\\" WIDEN (DICT_NAME) L".tri";

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -35,7 +35,7 @@
 
 #if defined (_WIN32) && !defined (__CYGWIN__)
 #include <wchar.h>
-/* turns a narrow string-literal macro into a wide one, e.g. WIDEN (DICT_NAME) */
+/* turns a narrow string-literal macro into a wide one */
 #define WIDEN_(s) L ## s
 #define WIDEN(s) WIDEN_(s)
 #endif
@@ -52,6 +52,23 @@ full_path (const char *path, const char *name, const char *ext)
     }
     return full_path_buff;
 }
+
+#if defined (_WIN32) && !defined (__CYGWIN__)
+static wchar_t *
+wfull_path (const wchar_t *path, const wchar_t *name, const wchar_t *ext)
+{
+    size_t full_size = wcslen (path) + wcslen (name) + wcslen (ext) + 2;
+    wchar_t *full_path_buff = (wchar_t *) malloc (full_size * sizeof (wchar_t));
+    if (LIKELY (full_path_buff)) {
+        /* Use wcscat; avoid swprintf inconsistency between Windows versions */
+        wcscpy (full_path_buff, path);
+        wcscat (full_path_buff, L"\\");
+        wcscat (full_path_buff, name);
+        wcscat (full_path_buff, ext);
+    }
+    return full_path_buff;
+}
+#endif
 
 Trie *
 brk_load_default_dict ()
@@ -72,23 +89,21 @@ brk_load_default_dict ()
     /* Then, fall back to default DICT_DIR macro */
     if (!dict_trie) {
 #if defined (_WIN32) && !defined (__CYGWIN__)
-        wchar_t *basedir = win_inst_dir ();
-        if (basedir) {
-            static const wchar_t sharedir[] =
-                L"share\\libthai\\" WIDEN (DICT_NAME) L".tri";
-            size_t total_len = wcslen (basedir) + 1 /* '\\' */
-                              + (sizeof (sharedir) / sizeof (wchar_t));
-            wchar_t *filepath = (wchar_t *) malloc (total_len * sizeof (wchar_t));
-            if (filepath) {
-                swprintf (filepath, total_len, L"%ls\\%ls", basedir, sharedir);
-                FILE *f = _wfopen (filepath, L"rb");
-                if (f) {
-                    dict_trie = trie_fread (f);
-                    fclose (f);
+        {
+            wchar_t *basedir = win_inst_dir ();
+            if (basedir) {
+                static const wchar_t sharename[] =
+                    L"share\\libthai\\" WIDEN (DICT_NAME);
+                wchar_t *filepath = wfull_path (basedir, sharename, L".tri");
+                if (filepath) {
+                    FILE *f = _wfopen (filepath, L"rb");
+                    if (f) {
+                        dict_trie = trie_fread (f);
+                        fclose (f);
+                    }
+                    free (filepath);
                 }
-                free (filepath);
             }
-            free (basedir);
         }
         if (!dict_trie)
             dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -86,30 +86,29 @@ brk_load_default_dict ()
         }
     }
 
-    /* Then, fall back to default DICT_DIR macro */
-    if (!dict_trie) {
 #if defined (_WIN32) && !defined (__CYGWIN__)
-        {
-            wchar_t *basedir = win_inst_dir ();
-            if (basedir) {
-                static const wchar_t sharename[] =
-                    L"share\\libthai\\" WIDEN (DICT_NAME);
-                wchar_t *filepath = wfull_path (basedir, sharename, L".tri");
-                if (filepath) {
-                    FILE *f = _wfopen (filepath, L"rb");
-                    if (f) {
-                        dict_trie = trie_fread (f);
-                        fclose (f);
-                    }
-                    free (filepath);
+    /* Try to find dict under the base dir used to install the DLL */
+    if (!dict_trie) {
+        wchar_t *basedir = win_inst_dir ();
+        if (basedir) {
+            static const wchar_t sharename[] =
+                L"share\\libthai\\" WIDEN (DICT_NAME);
+            wchar_t *filepath = wfull_path (basedir, sharename, L".tri");
+            if (filepath) {
+                FILE *f = _wfopen (filepath, L"rb");
+                if (f) {
+                    dict_trie = trie_fread (f);
+                    fclose (f);
                 }
+                free (filepath);
             }
         }
-        if (!dict_trie)
-            dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
-#else
-        dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
+    }
 #endif
+
+    /* Then, fall back to default DICT_DIR macro */
+    if (!dict_trie) {
+        dict_trie = trie_new_from_file (DICT_DIR "/" DICT_NAME ".tri");
     }
 
     return dict_trie;

--- a/src/thbrk/brk-common.c
+++ b/src/thbrk/brk-common.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
 /*
  * libthai - Thai Language Support Library
- * Copyright (C) 2001  Theppitak Karoonboonyanan <theppitak@gmail.com>
+ * Copyright (C) 2001-2026 Theppitak Karoonboonyanan <theppitak@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,7 @@
 
 #if defined (_WIN32) && !defined (__CYGWIN__)
 #include <wchar.h>
+#include "utils/win-utils.h"
 /* turns a narrow string-literal macro into a wide one */
 #define WIDEN_(s) L ## s
 #define WIDEN(s) WIDEN_(s)

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -2,5 +2,11 @@ MAINTAINERCLEANFILES = Makefile.in
 
 AM_CPPFLAGS = -I. -I$(top_srcdir)/src -I$(top_srcdir)/include $(DATRIE_CFLAGS)
 
-noinst_HEADERS = priv-utils.h
+noinst_LTLIBRARIES = libutils.la
+
+libutils_la_SOURCES = \
+	priv-utils.h \
+	win-utils.h \
+	win-utils.c \
+	$(NULL)
 

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -36,12 +36,11 @@
 #endif
 
 #if defined (_WIN32) && !defined (__CYGWIN__)
-/*
- * Resolves the absolute directory path of the loaded libthai DLL.
- * Returns a dynamically allocated string that must be free()d by the caller.
- * Returns NULL on failure.
- */
-char * th_get_win32_installdir (void);
+#include <wchar.h>
+
+/* Absolute directory of the loaded libthai DLL, or NULL on failure.
+ * Caller free()s the wide string. */
+wchar_t * th_get_win32_installdir_w (void);
 #endif
 
 #endif  /* __PRIV_UTILS_H */

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -19,7 +19,7 @@
  */
 
 /*
- * thbrk-utils.h - Common utilities for thbrk module
+ * priv-utils.h - Common private utilities
  * Created: 2015-05-06
  * Author:  Theppitak Karoonboonyanan <theppitak@gmail.com>
  */
@@ -35,9 +35,17 @@
 #define UNLIKELY(expr) (expr)
 #endif
 
+#if defined (_WIN32) && !defined (__CYGWIN__)
+/*
+ * Resolves the absolute directory path of the loaded libthai DLL.
+ * Returns a dynamically allocated string that must be free()d by the caller.
+ * Returns NULL on failure.
+ */
+char * libthai_get_installdir (void);
+#endif
+
 #endif  /* __PRIV_UTILS_H */
 
 /*
 vi:ts=4:ai:expandtab
 */
-

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -39,7 +39,8 @@
 #include <wchar.h>
 
 /* Absolute directory of the loaded libthai DLL, or NULL on failure.
- * Caller free()s the wide string. */
+ * The returned pointer is cached and owned by the library;
+ * valid for the process's lifetime, the caller must not free it. */
 wchar_t * win_inst_dir (void);
 #endif
 

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -40,7 +40,7 @@
 
 /* Absolute directory of the loaded libthai DLL, or NULL on failure.
  * Caller free()s the wide string. */
-wchar_t * th_get_win32_installdir_w (void);
+wchar_t * win_inst_dir (void);
 #endif
 
 #endif  /* __PRIV_UTILS_H */

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -41,7 +41,7 @@
  * Returns a dynamically allocated string that must be free()d by the caller.
  * Returns NULL on failure.
  */
-char * libthai_get_installdir (void);
+char * th_get_win32_installdir (void);
 #endif
 
 #endif  /* __PRIV_UTILS_H */

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -35,18 +35,6 @@
 #define UNLIKELY(expr) (expr)
 #endif
 
-#if defined (_WIN32) && !defined (__CYGWIN__)
-#include <wchar.h>
-
-/* Absolute directory of the loaded libthai DLL, or NULL on failure.
- * The returned pointer is cached and owned by the library;
- * valid for the process's lifetime, the caller must not free it. */
-wchar_t * win_inst_dir (void);
-
-/* Free the pointer cached by win_inst_dir(). Call once on unload. */
-void win_inst_dir_free (void);
-#endif
-
 #endif  /* __PRIV_UTILS_H */
 
 /*

--- a/src/utils/priv-utils.h
+++ b/src/utils/priv-utils.h
@@ -42,6 +42,9 @@
  * The returned pointer is cached and owned by the library;
  * valid for the process's lifetime, the caller must not free it. */
 wchar_t * win_inst_dir (void);
+
+/* Free the pointer cached by win_inst_dir(). Call once on unload. */
+void win_inst_dir_free (void);
 #endif
 
 #endif  /* __PRIV_UTILS_H */

--- a/src/utils/win-utils.c
+++ b/src/utils/win-utils.c
@@ -1,0 +1,153 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ * libthai - Thai Language Support Library
+ *
+ * SPDX-FileCopyrightText: 2001-2026 Theppitak Karoonboonyanan <theppitak@gmail.com>
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+/*
+ * win-utils.c - Windows-specific private utility functions
+ * Created: 2026-07-25
+ * Author: Arthit Suriyawongkul <suriyawa@tcd.ie>
+ */
+
+#include "utils/priv-utils.h"
+
+#if defined (_WIN32) && !defined (__CYGWIN__)
+#define WIN32_LEAN_AND_MEAN 1
+#include <windows.h>
+#include <stdlib.h>
+#include <wchar.h>
+
+void _libthai_on_unload (void);
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved);
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+    (void) hinstDLL;
+    if (fdwReason == DLL_PROCESS_DETACH) {
+        /* Skip cleanup if the whole process is exiting (lpvReserved != NULL);
+         * other DLLs may already be gone */
+        if (!lpvReserved)
+            _libthai_on_unload ();
+    }
+    return TRUE;
+}
+
+/* Reverse search for needle in the first n wchar_t of haystack;
+ * NULL if absent.
+ */
+static const wchar_t *
+wmemrchr_bound (const wchar_t *haystack, wchar_t needle, size_t n)
+{
+    const wchar_t *p;
+    if (n == 0)
+        return NULL;
+    for (p = haystack + n - 1; p >= haystack; --p) {
+        if (*p == needle)
+            return p;
+    }
+    return NULL;
+}
+
+/* True if s starts with marker (case-insensitively) followed by '\\'. */
+static int
+segment_matches (const wchar_t *s, const wchar_t *marker)
+{
+    size_t len = wcslen (marker);
+    return _wcsnicmp (s, marker, len) == 0 && s[len] == L'\\';
+}
+
+/* Install dir = parent of nearest "bin"/"lib"/"bin64"/"lib64" ancestor,
+ * else path's own dir.
+ * C:\Program Files\App\bin\libthai.dll -> C:\Program Files\App
+ * C:\Program Files\App\libthai.dll     -> C:\Program Files\App
+ */
+static wchar_t *
+win_find_inst_dir (const wchar_t *filepath)
+{
+    size_t n = wcslen (filepath);
+    const wchar_t *base_end = NULL;
+    size_t len;
+    wchar_t *result;
+
+    /* Scan segments right-to-left for a known install-layout marker dir */
+    for (;;) {
+        const wchar_t *p = wmemrchr_bound (filepath, L'\\', n);
+        if (!p)
+            break;
+        if (segment_matches (p + 1, L"bin") ||
+            segment_matches (p + 1, L"lib") ||
+            segment_matches (p + 1, L"bin64") ||
+            segment_matches (p + 1, L"lib64")) {
+            base_end = p;
+            break;
+        }
+        n = (size_t) (p - filepath);
+    }
+
+    /* Not found: fall back to the DLL's own directory */
+    if (!base_end) {
+        const wchar_t *p = wcsrchr (filepath, L'\\');
+        base_end = p ? p : filepath;
+    }
+
+    len = (size_t) (base_end - filepath);
+    result = (wchar_t *) malloc ((len + 1) * sizeof (wchar_t));
+    if (!result)
+        return NULL;
+    wmemcpy (result, filepath, len);
+    result[len] = L'\0';
+    return result;
+}
+
+static wchar_t *cached_dir = NULL;
+static int computed = 0;
+
+wchar_t *
+win_inst_dir (void)
+{
+    /* Windows stores paths natively as UTF-16 */
+    /* Cached: the install dir is invariant for the process's life. */
+    HMODULE hmod = NULL;
+    wchar_t *path;
+    DWORD len;
+
+    if (computed)
+        return cached_dir;
+    computed = 1;
+
+    if (!GetModuleHandleExW (GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                              (LPCWSTR) &win_inst_dir, &hmod))
+        return NULL;
+
+    path = (wchar_t *) malloc (MAX_PATH * sizeof (wchar_t));
+    if (!path)
+        return NULL;
+
+    len = GetModuleFileNameW (hmod, path, MAX_PATH);
+    if (len == 0 || len >= MAX_PATH) {
+        free (path);
+        return NULL;
+    }
+
+    cached_dir = win_find_inst_dir (path);
+    free (path);
+    return cached_dir;
+}
+
+void
+win_inst_dir_free (void)
+{
+    free (cached_dir);
+    cached_dir = NULL;
+    computed = 0;
+}
+#endif /* _WIN32 && !__CYGWIN__ */
+
+/*
+vi:ts=4:ai:expandtab
+*/

--- a/src/utils/win-utils.c
+++ b/src/utils/win-utils.c
@@ -8,12 +8,12 @@
  */
 
 /*
- * win-utils.c - Windows-specific private utility functions
+ * win-utils.c - Windows-specific private utilities
  * Created: 2026-07-25
  * Author: Arthit Suriyawongkul <suriyawa@tcd.ie>
  */
 
-#include "utils/priv-utils.h"
+#include "utils/win-utils.h"
 
 #if defined (_WIN32) && !defined (__CYGWIN__)
 #define WIN32_LEAN_AND_MEAN 1

--- a/src/utils/win-utils.h
+++ b/src/utils/win-utils.h
@@ -1,0 +1,35 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ * libthai - Thai Language Support Library
+ *
+ * SPDX-FileCopyrightText: 2001-2026 Theppitak Karoonboonyanan <theppitak@gmail.com>
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+/*
+ * win-utils.h - Windows-specific private utilities
+ * Created: 2026-07-29
+ * Author: Arthit Suriyawongkul <suriyawa@tcd.ie>
+ */
+
+#ifndef __WIN_UTILS_H
+#define __WIN_UTILS_H
+
+#if defined (_WIN32) && !defined (__CYGWIN__)
+#include <wchar.h>
+
+/* Absolute directory of the loaded libthai DLL, or NULL on failure.
+ * The returned pointer is cached and owned by the library;
+ * valid for the process's lifetime, the caller must not free it. */
+wchar_t * win_inst_dir (void);
+
+/* Free the pointer cached by win_inst_dir(). Call once on unload. */
+void win_inst_dir_free (void);
+#endif
+
+#endif  /* __WIN_UTILS_H */
+
+/*
+vi:ts=4:ai:expandtab
+*/


### PR DESCRIPTION
Find .dll for Windows to fix #7 and fix #17

Add `win_inst_dir` to handle path resolution for Windows.

Uses standard Windows APIs (partly based on https://github.com/tlwg/libthai/pull/12 by @fanc999 and from @thep 's suggestion in https://github.com/tlwg/libthai/pull/36#discussion_r3576082707):

- `GetModuleHandleExW`: To get the DLL module handle.
- `GetModuleFileNameW`: To retrieve the DLL's installation path (handle Unicode characters)

Tested with mingw-w64 (cross-compiled), macOS, Ubuntu.

--

Path resolution flow:

| # | Step | Function | Output |
| - | ---- | -------- | ------ |
| 1 | Get DLL module handle | `GetModuleHandleExW` (in `win_inst_dir`) | DLL handle, or NULL on failure |
| 2 | Get DLL full path | `GetModuleFileNameW` (in `win_inst_dir`) | DLL path = `C:\App\bin\libthai.dll` or `C:\App2\libthai.dll`, or NULL on failure |
| 3 | Get install path | `win_find_inst_dir` | Install dir = `C:\App` (remove "bin") or `C:\App2` (no "bin" found, just use the full dir), or `NULL` on malloc failure |
| 4 | Guess dictionary path | `wfull_path` (in `brk_load_default_dict`) | Dict path = `C:\App\share\libthai\thbrk.tri` or `C:\App2\share\libthai\thbrk.tri`, or NULL on malloc failure |
| 5 | Open guessed path |` _wfopen` (in `brk_load_default_dict`) | File handle, or NULL if no file exists there |
| 6 | Parse dictionary | `trie_fread` (in `brk_load_default_dict`) | `Trie *dict_trie`, or NULL if the file is bad |
| 7 | Fall back on any failure in 1-6 | `trie_new_from_file(DICT_DIR "/" DICT_NAME ".tri")` (in `brk_load_default_dict`) | Likely fails on Windows, but will bring us to regular fallback path before this patch |